### PR TITLE
Fix address/payment persistence and response parsing

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -170,16 +170,11 @@ export default function ProfilePage() {
     if (!res.ok) {
       // revert optimistic update
       setAddresses(prev);
-      if (res.status === 401) {
-        window.alert('Please sign in to save addresses');
-        // redirect to login so user can authenticate
-        window.location.href = '/login';
-        return;
-      }
+      // show generic failure without forcing sign-in redirect
       window.alert(res.error || 'Failed to save address');
       return;
     }
-    // success: nothing to do (server is source of truth)
+    // success
   }
 
   async function removeAddress(id: string) {
@@ -190,11 +185,7 @@ export default function ProfilePage() {
     const res = await persistToServer({ addresses: next });
     if (!res.ok) {
       setAddresses(prev);
-      if (res.status === 401) {
-        window.alert('Please sign in to remove addresses');
-        window.location.href = '/login';
-        return;
-      }
+      // show generic failure without forcing sign-in redirect
       window.alert(res.error || 'Failed to remove address');
       return;
     }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -110,6 +110,11 @@ export default function ProfilePage() {
           setOrdersCount(json.ordersCount ?? null);
           setServerWishlistCount(json.wishlistCount ?? null);
           setNameDraft(json.user.name || json.user.email.split('@')[0] || '');
+          // Load server-stored addresses and payment methods
+          try {
+            if (Array.isArray(json.user.addresses)) setAddresses(json.user.addresses);
+            if (Array.isArray(json.user.payment_methods)) setCards(json.user.payment_methods);
+          } catch {}
           // update auth context name if missing
           if (authUser && (!authUser.name || authUser.name !== json.user.name)) {
             try { update({ name: json.user.name }); } catch {}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -55,7 +55,9 @@ export default function ProfilePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: emailDraft }),
       });
-      const json = await res.json();
+      const text = await res.text().catch(() => '');
+      let json: any = {};
+      try { json = text ? JSON.parse(text) : {}; } catch {}
       if (!res.ok) throw new Error(json?.error || 'Failed to update');
       if (json && json.user) {
         setServerUser(json.user);
@@ -146,7 +148,9 @@ export default function ProfilePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      const json = await res.json();
+      const text = await res.text().catch(() => '');
+      let json: any = {};
+      try { json = text ? JSON.parse(text) : {}; } catch {}
       if (!res.ok) throw new Error(json?.error || 'Failed to save');
       if (json && json.user) {
         setServerUser(json.user);
@@ -206,7 +210,9 @@ export default function ProfilePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: nameDraft }),
       });
-      const json = await res.json();
+      const text = await res.text().catch(() => '');
+      let json: any = {};
+      try { json = text ? JSON.parse(text) : {}; } catch {}
       if (!res.ok) throw new Error(json?.error || 'Failed to update name');
       if (json && json.user) {
         setServerUser(json.user);
@@ -416,7 +422,7 @@ export default function ProfilePage() {
                       <div key={a.id} className={styles.addressRow}>
                         <div>
                           <div style={{ fontWeight: 700 }}>{a.label}</div>
-                          <div className="text-muted">{a.fullName} �� {a.phone}</div>
+                          <div className="text-muted">{a.fullName} · {a.phone}</div>
                           <div className="text-muted">{a.street}, {a.city}, {a.state} {a.zip}, {a.country}</div>
                         </div>
                         <div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -68,11 +68,11 @@ export default function ProfilePage() {
   }
 
   // Addresses state
-  const [addresses, setAddresses] = useState<any[]>(() => readJson<any[]>("addresses", []));
+  const [addresses, setAddresses] = useState<any[]>([]);
   const [addressForm, setAddressForm] = useState({ label: "Home", fullName: "", street: "", city: "", state: "", zip: "", country: "", phone: "" });
 
   // Payment methods
-  const [cards, setCards] = useState<any[]>(() => readJson<any[]>("payment_methods", []));
+  const [cards, setCards] = useState<any[]>([]);
   const [cardForm, setCardForm] = useState({ name: "", number: "", expiry: "" });
 
   // Account settings

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -80,8 +80,6 @@ export default function ProfilePage() {
   const [connected, setConnected] = useState<{ provider: string; connected: boolean }[]>(() => readJson("connected_accounts", [{ provider: "Google", connected: false }, { provider: "GitHub", connected: false }]));
   const [password, setPassword] = useState({ current: "", next: "", confirm: "" });
 
-  useEffect(() => writeJson("addresses", addresses), [addresses]);
-  useEffect(() => writeJson("payment_methods", cards), [cards]);
   useEffect(() => writeJson("preferences", prefs), [prefs]);
   useEffect(() => writeJson("connected_accounts", connected), [connected]);
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -55,8 +55,8 @@ export default function ProfilePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: emailDraft }),
       });
-      if (!res.ok) throw new Error((await res.json()).error || 'Failed to update');
       const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || 'Failed to update');
       if (json && json.user) {
         setServerUser(json.user);
         setEditingEmail(false);
@@ -146,8 +146,8 @@ export default function ProfilePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      if (!res.ok) throw new Error((await res.json()).error || 'Failed to save');
       const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || 'Failed to save');
       if (json && json.user) {
         setServerUser(json.user);
       }
@@ -206,8 +206,8 @@ export default function ProfilePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: nameDraft }),
       });
-      if (!res.ok) throw new Error('Failed to update name');
       const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || 'Failed to update name');
       if (json && json.user) {
         setServerUser(json.user);
         try { update({ name: json.user.name }); } catch {}
@@ -416,7 +416,7 @@ export default function ProfilePage() {
                       <div key={a.id} className={styles.addressRow}>
                         <div>
                           <div style={{ fontWeight: 700 }}>{a.label}</div>
-                          <div className="text-muted">{a.fullName} · {a.phone}</div>
+                          <div className="text-muted">{a.fullName} �� {a.phone}</div>
                           <div className="text-muted">{a.street}, {a.city}, {a.state} {a.zip}, {a.country}</div>
                         </div>
                         <div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -212,12 +212,9 @@ export default function ProfilePage() {
 
     const res = await persistToServer({ payment_methods: next });
     if (!res.ok) {
+      // revert optimistic update
       setCards(prev);
-      if (res.status === 401) {
-        window.alert('Please sign in to save payment methods');
-        window.location.href = '/login';
-        return;
-      }
+      // show generic failure without forcing sign-in redirect
       window.alert(res.error || 'Failed to save card');
       return;
     }
@@ -232,11 +229,7 @@ export default function ProfilePage() {
     const res = await persistToServer({ payment_methods: next });
     if (!res.ok) {
       setCards(prev);
-      if (res.status === 401) {
-        window.alert('Please sign in to remove payment methods');
-        window.location.href = '/login';
-        return;
-      }
+      // show generic failure without forcing sign-in redirect
       window.alert(res.error || 'Failed to remove card');
       return;
     }


### PR DESCRIPTION
## Purpose

Users were experiencing multiple issues with the profile page:
- "Failed to execute 'json' on 'Response': body stream already read" errors when updating profile data
- "Failed to save" errors when adding addresses and payment methods
- Addresses and payment methods were being saved locally instead of to the database
- Unnecessary sign-in validation messages appearing for authenticated users

## Code changes

**Fixed response parsing issues:**
- Replaced direct `res.json()` calls with safer `res.text()` + `JSON.parse()` pattern to prevent "body stream already read" errors
- Added proper error handling for malformed JSON responses

**Migrated to server-backed storage:**
- Removed local storage persistence for addresses and payment methods
- Added `persistToServer()` function to handle API calls for saving data to database
- Updated address/payment CRUD operations to use optimistic updates with server persistence
- Load addresses and payment methods from server user data on profile fetch

**Improved error handling:**
- Added graceful fallbacks for failed server operations
- Removed forced sign-in redirects, showing generic error messages instead
- Implemented optimistic UI updates with rollback on server failures

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2302e2634e484c24ae6f66b45ffc4cb0/neon-garden)

👀 [Preview Link](https://2302e2634e484c24ae6f66b45ffc4cb0-neon-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2302e2634e484c24ae6f66b45ffc4cb0</projectId>-->
<!--<branchName>neon-garden</branchName>-->